### PR TITLE
[README.md] it fixes link to the bitcart orb registry page #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This orb is used across Bitcart repositories to reduce duplication and improve m
 
 ## Resources
 
-[CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/bitcart/bitcart-orb) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+[CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/bitcart/bitcart-shared) - The official registry page of this orb for all versions, executors, commands, and jobs described.
 [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) - Docs for using and creating CircleCI Orbs.
 
 ### How to Contribute


### PR DESCRIPTION
the current bitcart-orb url leads to a 404 page